### PR TITLE
Rough first take on LP stats UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@popperjs/core": "^2.10.1",
     "@reduxjs/toolkit": "^1.6.1",
-    "@stellar/design-system": "^0.4.0",
+    "@stellar/design-system": "^0.4.1",
     "amplitude-js": "^8.4.0",
     "bignumber.js": "^9.0.1",
     "lodash": "^4.17.21",

--- a/src/components/AssetAvatar.tsx
+++ b/src/components/AssetAvatar.tsx
@@ -1,30 +1,10 @@
 import { useEffect, useState } from "react";
-import { getIconUrlFromIssuer } from "helpers/getIconUrlFromIssuer";
+import { getAssetAvatarProps } from "helpers/getAssetAvatarProps";
 import { Avatar } from "components/Avatar";
-import StellarLogo from "assets/stellar-logo.png";
 
 interface AvatarProps {
   assets: string[];
 }
-
-const getCodeAndKey = (asset: string) => {
-  const splitArr = asset.split(":");
-
-  return {
-    assetCode: splitArr[0],
-    issuerKey: splitArr[1],
-  };
-};
-
-const DEFAULT_ASSET = {
-  altText: "",
-  iconUrl: "",
-};
-
-const NATIVE_ASSET = {
-  altText: "XLM",
-  iconUrl: StellarLogo,
-};
 
 export const AssetAvatar = ({ assets }: AvatarProps) => {
   type Icon = { altText: string; iconUrl: string };
@@ -36,7 +16,10 @@ export const AssetAvatar = ({ assets }: AvatarProps) => {
 
     // eslint-disable-next-line @typescript-eslint/prefer-for-of
     for (let i = 0; i < assets.length; i++) {
-      iconDefaults.push(DEFAULT_ASSET);
+      iconDefaults.push({
+        altText: `asset-${i}`,
+        iconUrl: "",
+      });
     }
 
     setIcons(iconDefaults);
@@ -50,27 +33,8 @@ export const AssetAvatar = ({ assets }: AvatarProps) => {
     };
 
     assets.forEach(async (asset, index) => {
-      if (asset !== "native") {
-        const { assetCode, issuerKey } = getCodeAndKey(asset);
-        const iconUrl = await getIconUrlFromIssuer({
-          assetCode,
-          issuerKey,
-        });
-
-        setIcons((prevIcons) =>
-          updateAssetIcon(prevIcons, index, {
-            altText: assetCode,
-            iconUrl,
-          }),
-        );
-      } else {
-        setIcons((prevIcons) =>
-          updateAssetIcon(prevIcons, index, {
-            altText: NATIVE_ASSET.altText,
-            iconUrl: NATIVE_ASSET.iconUrl,
-          }),
-        );
-      }
+      const avatarProps = await getAssetAvatarProps(asset);
+      setIcons((prevIcons) => updateAssetIcon(prevIcons, index, avatarProps));
     });
   }, [assets]);
 

--- a/src/components/AssetConversions/index.tsx
+++ b/src/components/AssetConversions/index.tsx
@@ -1,20 +1,29 @@
 import { findIndex } from "lodash";
+import { Avatar } from "components/Avatar";
 import { AssetAvatar } from "components/AssetAvatar";
 import { formatConversion } from "helpers/formatConversion";
 import { getAssetCode } from "helpers/getAssetCode";
-import { LiquidityPoolReserve } from "types/types.d";
+import {
+  LiquidityPoolReserve,
+  AssetAvatar as AssetAvatarType,
+} from "types/types.d";
 import "./styles.scss";
 
 interface AssetConversionsProps {
   reserves: LiquidityPoolReserve[];
+  avatars?: AssetAvatarType[];
 }
 
 type AssetProps = {
   fromAsset: LiquidityPoolReserve;
   toAsset: LiquidityPoolReserve;
+  avatar?: AssetAvatarType;
 };
 
-export const AssetConversions = ({ reserves }: AssetConversionsProps) => {
+export const AssetConversions = ({
+  reserves,
+  avatars,
+}: AssetConversionsProps) => {
   if (reserves.length !== 2) {
     throw new Error("AssetConversions component must have two (2) assets.");
   }
@@ -36,9 +45,13 @@ export const AssetConversions = ({ reserves }: AssetConversionsProps) => {
     return `${formatConversion(num)} ${getAssetCode(reserves[index].asset)}`;
   };
 
-  const Asset = ({ fromAsset, toAsset }: AssetProps) => (
+  const Asset = ({ fromAsset, toAsset, avatar }: AssetProps) => (
     <div className="AssetConversions__asset">
-      <AssetAvatar assets={[fromAsset.asset]} />
+      {avatar ? (
+        <Avatar source={[avatar]} />
+      ) : (
+        <AssetAvatar assets={[fromAsset.asset]} />
+      )}
       <span>{`1 ${getAssetCode(fromAsset.asset)} = ${getConversion(
         toAsset,
       )}`}</span>
@@ -47,8 +60,16 @@ export const AssetConversions = ({ reserves }: AssetConversionsProps) => {
 
   return (
     <div className="AssetConversions">
-      <Asset fromAsset={reserves[0]} toAsset={reserves[1]} />
-      <Asset fromAsset={reserves[1]} toAsset={reserves[0]} />
+      <Asset
+        fromAsset={reserves[0]}
+        toAsset={reserves[1]}
+        {...(avatars ? { avatar: avatars[0] } : {})}
+      />
+      <Asset
+        fromAsset={reserves[1]}
+        toAsset={reserves[0]}
+        {...(avatars ? { avatar: avatars[1] } : {})}
+      />
     </div>
   );
 };

--- a/src/components/PoolStats/index.tsx
+++ b/src/components/PoolStats/index.tsx
@@ -1,0 +1,146 @@
+import React, { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { Avatar } from "components/Avatar";
+import { Card } from "components/Card";
+import { StatItem } from "components/StatItem";
+import { fetchPoolStatsAction } from "ducks/poolStats";
+import { formatAmount } from "helpers/formatAmount";
+import { formatConversion } from "helpers/formatConversion";
+import { useRedux } from "hooks/useRedux";
+import {
+  LiquidityPoolReserve,
+  LiquidityPoolAssetInterval,
+} from "types/types.d";
+import "./styles.scss";
+
+export const PoolStats = () => {
+  const { poolAvatars, poolInfo, poolStats } = useRedux(
+    "poolAvatars",
+    "poolInfo",
+    "poolStats",
+  );
+
+  const dispatch = useDispatch();
+  const poolId = poolInfo.data?.id;
+
+  useEffect(() => {
+    if (poolId) {
+      dispatch(fetchPoolStatsAction(poolId));
+    }
+  }, [dispatch, poolId]);
+
+  const getAssetByAssetCode = ({
+    assets,
+    assetCode,
+  }: {
+    assets?: any[];
+    assetCode: string;
+  }) => (assets || []).find((a) => a.assetCode === assetCode);
+
+  const formatAssetAmount = (asset?: LiquidityPoolReserve) => {
+    if (!asset) {
+      return "";
+    }
+
+    return `${formatConversion(asset.amount)} ${asset.assetCode}`;
+  };
+
+  const formatIntervalAmount = (asset?: LiquidityPoolAssetInterval) => {
+    if (!asset) {
+      return "";
+    }
+
+    return `${formatConversion(asset["24h"])} ${asset.assetCode}`;
+  };
+
+  if (!poolInfo.data || !poolStats.data) {
+    return null;
+  }
+
+  const renderPooledTokens = () => (
+    <>
+      <div className="PoolStats__token">
+        <Avatar source={[poolAvatars.data[0]]} />{" "}
+        {formatAssetAmount(
+          getAssetByAssetCode({
+            assets: poolStats.data?.assets,
+            assetCode: poolAvatars.data[0].altText,
+          }),
+        )}
+      </div>
+      <div className="PoolStats__token">
+        <Avatar source={[poolAvatars.data[1]]} />{" "}
+        {formatAssetAmount(
+          getAssetByAssetCode({
+            assets: poolStats.data?.assets,
+            assetCode: poolAvatars.data[1].altText,
+          }),
+        )}
+      </div>
+    </>
+  );
+
+  const statsData = [
+    {
+      id: "vol-24h",
+      label: "Volume 24h",
+      content: formatIntervalAmount(
+        getAssetByAssetCode({
+          assets: poolStats.data?.volume,
+          assetCode: poolAvatars.data[0].altText,
+        }),
+      ),
+      // TODO: add details
+      details: "Details",
+      // note: "+$131,500 (+5.11%)",
+      // isNoteNegative: false,
+    },
+    {
+      id: "fees-24h",
+      label: "Fees 24h",
+      content: formatIntervalAmount(
+        getAssetByAssetCode({
+          assets: poolStats.data?.earnedFees,
+          assetCode: poolAvatars.data[0].altText,
+        }),
+      ),
+      // TODO: add details
+      details: "Details",
+      // note: "-$8,361.02 (-5.11%)",
+      // isNoteNegative: true,
+    },
+    {
+      id: "participants",
+      label: "Participants",
+      content: formatAmount(poolInfo.data.totalTrustlines),
+      // TODO: add details
+      details: "Details",
+    },
+  ];
+
+  return (
+    <Card>
+      <div className="PoolStats">
+        <div className="PoolStats__items">
+          {statsData.map((s) => (
+            <React.Fragment key={s.id}>
+              <StatItem
+                label={s.label}
+                details={s.details}
+                // note={s.note}
+                // isNoteNegative={Boolean(s.isNoteNegative)}
+              >
+                {s.content}
+              </StatItem>
+            </React.Fragment>
+          ))}
+        </div>
+
+        {/* TODO: add details */}
+        <StatItem label="Pooled Tokens" details="Details">
+          {renderPooledTokens()}
+        </StatItem>
+      </div>
+    </Card>
+  );
+};

--- a/src/components/PoolStats/styles.scss
+++ b/src/components/PoolStats/styles.scss
@@ -1,7 +1,7 @@
 .PoolStats {
   &__items {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
     column-gap: 2rem;
     row-gap: 1.5rem;
     margin-bottom: 1.5rem;

--- a/src/components/PoolStats/styles.scss
+++ b/src/components/PoolStats/styles.scss
@@ -1,0 +1,22 @@
+.PoolStats {
+  &__items {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    column-gap: 2rem;
+    row-gap: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  &__token {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 1rem;
+    line-height: 1.75rem;
+
+    .Avatar {
+      --Avatar-size: 1.5rem;
+      --Avatar-border-color: var(--pal-border-primary);
+    }
+  }
+}

--- a/src/components/StatItem/index.tsx
+++ b/src/components/StatItem/index.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { IconButton, Icon } from "@stellar/design-system";
+import { Tooltip } from "components/Tooltip";
+import "./styles.scss";
+
+interface StatItemProps {
+  label: string;
+  details?: React.ReactNode;
+  note?: string;
+  isNoteNegative?: boolean;
+  children: React.ReactNode;
+}
+
+export const StatItem = ({
+  label,
+  details,
+  note,
+  isNoteNegative,
+  children,
+}: StatItemProps) => (
+  <div className="StatItem">
+    <div className="StatItem__label">
+      <span>{label}</span>
+
+      {details ? (
+        <Tooltip position={Tooltip.position.TOP} content={details}>
+          <IconButton
+            icon={<Icon.Info />}
+            altText="Details"
+            customSize="1rem"
+          />
+        </Tooltip>
+      ) : null}
+    </div>
+    <div className="StatItem__text">{children}</div>
+    {note ? (
+      <div
+        className={`StatItem__note StatItem__note--${
+          isNoteNegative ? "negative" : "positive"
+        }`}
+      >
+        {note}
+      </div>
+    ) : null}
+  </div>
+);

--- a/src/components/StatItem/styles.scss
+++ b/src/components/StatItem/styles.scss
@@ -15,7 +15,7 @@
   }
 
   &__text {
-    font-size: 1.25rem;
+    font-size: 1.125rem;
     line-height: 1.75rem;
     color: var(--pal-text-primary);
     font-weight: var(--font-weight-medium);

--- a/src/components/StatItem/styles.scss
+++ b/src/components/StatItem/styles.scss
@@ -1,0 +1,37 @@
+.StatItem {
+  &__label {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    margin-bottom: 0.5rem;
+
+    span {
+      text-transform: uppercase;
+      font-size: var(--font-size-secondary);
+      line-height: 1.375rem;
+      color: var(--pal-text-secondary);
+      font-weight: var(--font-weight-medium);
+    }
+  }
+
+  &__text {
+    font-size: 1.25rem;
+    line-height: 1.75rem;
+    color: var(--pal-text-primary);
+    font-weight: var(--font-weight-medium);
+  }
+
+  &__note {
+    font-size: 0.75rem;
+    line-height: 1.25rem;
+    font-weight: var(--font-weight-medium);
+
+    &--positive {
+      color: var(--pal-success);
+    }
+
+    &--negative {
+      color: var(--pal-error);
+    }
+  }
+}

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -11,6 +11,7 @@ import { RESET_STORE_ACTION_TYPE } from "constants/settings";
 
 import { reducer as poolAvatars } from "ducks/poolAvatars";
 import { reducer as poolInfo } from "ducks/poolInfo";
+import { reducer as poolStats } from "ducks/poolStats";
 import { reducer as poolTransactions } from "ducks/poolTransactions";
 
 export type RootState = ReturnType<typeof store.getState>;
@@ -29,6 +30,7 @@ const isSerializable = (value: any) =>
 const reducers = combineReducers({
   poolAvatars,
   poolInfo,
+  poolStats,
   poolTransactions,
 });
 

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -9,6 +9,7 @@ import BigNumber from "bignumber.js";
 
 import { RESET_STORE_ACTION_TYPE } from "constants/settings";
 
+import { reducer as poolAvatars } from "ducks/poolAvatars";
 import { reducer as poolInfo } from "ducks/poolInfo";
 import { reducer as poolTransactions } from "ducks/poolTransactions";
 
@@ -26,6 +27,7 @@ const isSerializable = (value: any) =>
   BigNumber.isBigNumber(value) || isPlain(value);
 
 const reducers = combineReducers({
+  poolAvatars,
   poolInfo,
   poolTransactions,
 });

--- a/src/ducks/poolAvatars.ts
+++ b/src/ducks/poolAvatars.ts
@@ -69,7 +69,7 @@ const poolAvatarsSlice = createSlice({
   },
 });
 
-export const poolInfoSelector = (state: RootState) => state.poolInfo;
+export const poolAvatarsSelector = (state: RootState) => state.poolAvatars;
 
 export const { reducer } = poolAvatarsSlice;
 export const { resetPoolAvatarsAction } = poolAvatarsSlice.actions;

--- a/src/ducks/poolAvatars.ts
+++ b/src/ducks/poolAvatars.ts
@@ -1,0 +1,75 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import { RootState } from "config/store";
+import { getErrorString } from "helpers/getErrorString";
+import { getAssetAvatarProps } from "helpers/getAssetAvatarProps";
+import {
+  ActionStatus,
+  RejectMessage,
+  PoolAvatarsInitialState,
+  LiquidityPoolReserve,
+  AssetAvatar,
+} from "types/types.d";
+
+export const fetchPoolAvatarsAction = createAsyncThunk<
+  AssetAvatar[],
+  LiquidityPoolReserve[],
+  { rejectValue: RejectMessage; state: RootState }
+>(
+  "poolAvatars/fetchPoolAvatarsAction",
+  async (reserves, { rejectWithValue }) => {
+    let assetAvatars = [];
+
+    try {
+      assetAvatars = await Promise.all(
+        reserves.map((r) => getAssetAvatarProps(r.asset)),
+      );
+    } catch (error) {
+      return rejectWithValue({
+        errorString: getErrorString(error),
+      });
+    }
+
+    return assetAvatars;
+  },
+);
+
+const initialState: PoolAvatarsInitialState = {
+  data: [
+    {
+      altText: "asset-1",
+      iconUrl: "",
+    },
+    {
+      altText: "asset-2",
+      iconUrl: "",
+    },
+  ],
+  status: undefined,
+  errorString: undefined,
+};
+
+const poolAvatarsSlice = createSlice({
+  name: "poolAvatars",
+  initialState,
+  reducers: {
+    resetPoolAvatarsAction: () => initialState,
+  },
+  extraReducers: (builder) => {
+    builder.addCase(fetchPoolAvatarsAction.pending, (state = initialState) => {
+      state.status = ActionStatus.PENDING;
+    });
+    builder.addCase(fetchPoolAvatarsAction.fulfilled, (state, action) => {
+      state.data = action.payload;
+      state.status = ActionStatus.SUCCESS;
+    });
+    builder.addCase(fetchPoolAvatarsAction.rejected, (state, action) => {
+      state.status = ActionStatus.ERROR;
+      state.errorString = action.payload?.errorString;
+    });
+  },
+});
+
+export const poolInfoSelector = (state: RootState) => state.poolInfo;
+
+export const { reducer } = poolAvatarsSlice;
+export const { resetPoolAvatarsAction } = poolAvatarsSlice.actions;

--- a/src/ducks/poolStats.ts
+++ b/src/ducks/poolStats.ts
@@ -1,0 +1,60 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import { RootState } from "config/store";
+import { getErrorString } from "helpers/getErrorString";
+import { fetchPoolStats } from "helpers/fetchPoolStats";
+import {
+  ActionStatus,
+  RejectMessage,
+  PoolStatsInitialState,
+  LiquidityPoolStats,
+} from "types/types.d";
+
+export const fetchPoolStatsAction = createAsyncThunk<
+  LiquidityPoolStats,
+  string,
+  { rejectValue: RejectMessage; state: RootState }
+>("poolAvatars/fetchPoolStatsAction", async (poolId, { rejectWithValue }) => {
+  let poolStats = null;
+
+  try {
+    poolStats = await fetchPoolStats(poolId);
+  } catch (error) {
+    return rejectWithValue({
+      errorString: getErrorString(error),
+    });
+  }
+
+  return poolStats;
+});
+
+const initialState: PoolStatsInitialState = {
+  data: null,
+  status: undefined,
+  errorString: undefined,
+};
+
+const poolStatsSlice = createSlice({
+  name: "poolStats",
+  initialState,
+  reducers: {
+    resetPoolStatsAction: () => initialState,
+  },
+  extraReducers: (builder) => {
+    builder.addCase(fetchPoolStatsAction.pending, (state = initialState) => {
+      state.status = ActionStatus.PENDING;
+    });
+    builder.addCase(fetchPoolStatsAction.fulfilled, (state, action) => {
+      state.data = action.payload;
+      state.status = ActionStatus.SUCCESS;
+    });
+    builder.addCase(fetchPoolStatsAction.rejected, (state, action) => {
+      state.status = ActionStatus.ERROR;
+      state.errorString = action.payload?.errorString;
+    });
+  },
+});
+
+export const poolStatsSelector = (state: RootState) => state.poolStats;
+
+export const { reducer } = poolStatsSlice;
+export const { resetPoolStatsAction } = poolStatsSlice.actions;

--- a/src/helpers/fetchPoolStats.ts
+++ b/src/helpers/fetchPoolStats.ts
@@ -1,0 +1,27 @@
+import { STELLAR_EXPERT_AMM_URL } from "constants/apiUrls";
+import { getAssetCode } from "helpers/getAssetCode";
+import { LiquidityPoolStats } from "types/types.d";
+
+export const fetchPoolStats = async (
+  poolId: string,
+): Promise<LiquidityPoolStats> => {
+  const response = await fetch(
+    `${STELLAR_EXPERT_AMM_URL}/pool/${poolId}/stats`,
+  );
+  const data = await response.json();
+
+  // TODO: any type
+  const addAssetCode = (items: any[]) =>
+    items.map((i) => ({ assetCode: getAssetCode(i.asset, "-"), ...i }));
+
+  return {
+    id: data.id,
+    assets: addAssetCode(data.assets),
+    earnedFees: addAssetCode(data.earned_fees),
+    fee: data.fee,
+    shares: data.shares,
+    totalValueLocked: data.total_value_locked,
+    tradesCount: data.trades,
+    volume: addAssetCode(data.volume),
+  };
+};

--- a/src/helpers/formatAmount.ts
+++ b/src/helpers/formatAmount.ts
@@ -1,4 +1,4 @@
 import { BigNumber } from "bignumber.js";
 
 export const formatAmount = (amount: string | number) =>
-  new BigNumber(amount).toString();
+  new BigNumber(amount).toFormat();

--- a/src/helpers/formatConversion.ts
+++ b/src/helpers/formatConversion.ts
@@ -3,16 +3,22 @@ import BigNumber from "bignumber.js";
 export const formatConversion = (amount: string | number) => {
   const num = new BigNumber(amount);
 
+  // billion
+  const b = 1000000000;
+  if (num.gte(b)) {
+    return `${num.div(b).toFormat(2)}b`;
+  }
+
   // million
   const m = 1000000;
   if (num.gte(m)) {
-    return `${num.div(m).toFixed(2)}m`;
+    return `${num.div(m).toFormat(2)}m`;
   }
 
   // thousand
   const k = 1000;
   if (num.gte(k)) {
-    return `${num.div(k).toFixed(2)}k`;
+    return `${num.div(k).toFormat(2)}k`;
   }
 
   // smallest amount
@@ -21,5 +27,5 @@ export const formatConversion = (amount: string | number) => {
     return `<${min}`;
   }
 
-  return `${num.toFixed(3)}`;
+  return `${num.toFormat(3)}`;
 };

--- a/src/helpers/getAssetAvatarProps.ts
+++ b/src/helpers/getAssetAvatarProps.ts
@@ -1,0 +1,33 @@
+import { getIconUrlFromIssuer } from "helpers/getIconUrlFromIssuer";
+import StellarLogo from "assets/stellar-logo.png";
+
+const getCodeAndKey = (asset: string) => {
+  const splitArr = asset.split(":");
+
+  return {
+    assetCode: splitArr[0],
+    issuerKey: splitArr[1],
+  };
+};
+
+export const getAssetAvatarProps = async (assetString: string) => {
+  // Native asset
+  if (["native", "XLM"].includes(assetString)) {
+    return {
+      altText: "XLM",
+      iconUrl: StellarLogo,
+    };
+  }
+
+  // Non-native asset
+  const { assetCode, issuerKey } = getCodeAndKey(assetString);
+  const iconUrl = await getIconUrlFromIssuer({
+    assetCode,
+    issuerKey,
+  });
+
+  return {
+    altText: assetCode,
+    iconUrl,
+  };
+};

--- a/src/helpers/getAssetCode.ts
+++ b/src/helpers/getAssetCode.ts
@@ -1,2 +1,4 @@
-export const getAssetCode = (assetString: string) =>
-  assetString === "native" ? "XLM" : assetString.split(":")[0];
+export const getAssetCode = (assetString: string, splitChar?: string) =>
+  ["native", "XLM"].includes(assetString)
+    ? "XLM"
+    : assetString.split(splitChar || ":")[0];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -3,7 +3,7 @@ import { rest } from "msw";
 import { STELLAR_EXPERT_AMM_URL } from "constants/apiUrls";
 
 export const handlers = [
-  rest.get(`${STELLAR_EXPERT_AMM_URL}/pool/1/stats`, (_req, res, ctx) =>
+  rest.get(`${STELLAR_EXPERT_AMM_URL}/pool/:id/stats`, (_req, res, ctx) =>
     res(
       ctx.status(200),
       ctx.json({
@@ -56,7 +56,7 @@ export const handlers = [
       }),
     ),
   ),
-  rest.get(`${STELLAR_EXPERT_AMM_URL}/pool/1/history`, (_req, res, ctx) =>
+  rest.get(`${STELLAR_EXPERT_AMM_URL}/pool/:id/history`, (_req, res, ctx) =>
     res(
       ctx.status(200),
       ctx.json({

--- a/src/pages/PoolDetails.tsx
+++ b/src/pages/PoolDetails.tsx
@@ -2,9 +2,13 @@ import { useEffect } from "react";
 import { Layout, Heading2 } from "@stellar/design-system";
 import { useParams, useHistory } from "react-router-dom";
 import { useDispatch } from "react-redux";
-import { AssetAvatar } from "components/AssetAvatar";
+import { Avatar } from "components/Avatar";
 import { AssetConversions } from "components/AssetConversions";
 import { Breadcrumbs } from "components/Breadcrumbs";
+import {
+  fetchPoolAvatarsAction,
+  resetPoolAvatarsAction,
+} from "ducks/poolAvatars";
 import { fetchPoolInfoAction, resetPoolInfoAction } from "ducks/poolInfo";
 import { useRedux } from "hooks/useRedux";
 
@@ -12,7 +16,7 @@ export const PoolDetails = () => {
   const dispatch = useDispatch();
   const history = useHistory();
 
-  const { poolInfo } = useRedux("poolInfo");
+  const { poolInfo, poolAvatars } = useRedux("poolInfo", "poolAvatars");
   const { poolId } = useParams<{ poolId: string }>();
 
   useEffect(() => {
@@ -22,6 +26,16 @@ export const PoolDetails = () => {
       dispatch(resetPoolInfoAction());
     };
   }, [dispatch, poolId]);
+
+  useEffect(() => {
+    if (poolInfo.data?.reserves) {
+      dispatch(fetchPoolAvatarsAction(poolInfo.data.reserves));
+    }
+
+    return () => {
+      dispatch(resetPoolAvatarsAction());
+    };
+  }, [dispatch, poolInfo.data?.reserves]);
 
   const handleRouteClick = (route: string) => {
     history.push(route);
@@ -50,15 +64,13 @@ export const PoolDetails = () => {
           onClick={handleRouteClick}
         />
         <div className="PoolDetails__title">
-          <AssetAvatar
-            assets={[
-              poolInfo.data.reserves[0].asset,
-              poolInfo.data.reserves[1].asset,
-            ]}
-          />
+          <Avatar source={poolAvatars.data} />
           <Heading2>{getAssetPairString()}</Heading2>
         </div>
-        <AssetConversions reserves={poolInfo.data.reserves} />
+        <AssetConversions
+          reserves={poolInfo.data.reserves}
+          avatars={poolAvatars.data}
+        />
       </Layout.Inset>
     </div>
   );

--- a/src/pages/PoolDetails.tsx
+++ b/src/pages/PoolDetails.tsx
@@ -5,6 +5,7 @@ import { useDispatch } from "react-redux";
 import { Avatar } from "components/Avatar";
 import { AssetConversions } from "components/AssetConversions";
 import { Breadcrumbs } from "components/Breadcrumbs";
+import { PoolStats } from "components/PoolStats";
 import {
   fetchPoolAvatarsAction,
   resetPoolAvatarsAction,
@@ -71,6 +72,10 @@ export const PoolDetails = () => {
           reserves={poolInfo.data.reserves}
           avatars={poolAvatars.data}
         />
+
+        <div>
+          <PoolStats />
+        </div>
       </Layout.Inset>
     </div>
   );

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -6,6 +6,11 @@
   .ProjectLogo__title {
     display: none;
   }
+
+  // Making it default for now
+  .Avatar {
+    --Avatar-image-size: 100%;
+  }
 }
 
 .Section {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -47,19 +47,24 @@ export interface PoolTransactionsInitialState {
   errorString?: string;
 }
 
-// Liquidity pool
-export interface LiquidityPoolReserve {
+export interface LiquidityPoolAsset {
   asset: string;
-  amount: string;
   assetCode?: string;
+  amount?: string;
+  "24h"?: string;
+  "7d"?: string;
+  "1y"?: string;
 }
 
-export interface LiquidityPoolAssetInterval {
-  asset: string;
+// Liquidity pool
+export interface LiquidityPoolReserve extends LiquidityPoolAsset {
+  amount: string;
+}
+
+export interface LiquidityPoolAssetInterval extends LiquidityPoolAsset {
   "24h": string;
   "7d": string;
   "1y": string;
-  assetCode?: string;
 }
 export interface LiquidityPoolOperation {
   [key: string]: any;

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -17,12 +17,18 @@ export interface RejectMessage {
 
 // Store
 export interface Store {
+  poolAvatars: PoolAvatarsInitialState;
   poolInfo: PoolInfoInitialState;
   poolTransactions: PoolTransactionsInitialState;
 }
 
 export type StoreKey = keyof Store;
 
+export interface PoolAvatarsInitialState {
+  data: AssetAvatar[];
+  status: ActionStatus | undefined;
+  errorString?: string;
+}
 export interface PoolInfoInitialState {
   data: LiquidityPoolInfo | null;
   status: ActionStatus | undefined;
@@ -60,6 +66,11 @@ export interface LiquidityPoolTransaction {
   reserves: LiquidityPoolReserve[];
   transactionHash: string;
   type: string;
+}
+
+export interface AssetAvatar {
+  altText: string;
+  iconUrl: string | undefined;
 }
 
 export interface LiquidityPoolInfo {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -19,6 +19,7 @@ export interface RejectMessage {
 export interface Store {
   poolAvatars: PoolAvatarsInitialState;
   poolInfo: PoolInfoInitialState;
+  poolStats: PoolStatsInitialState;
   poolTransactions: PoolTransactionsInitialState;
 }
 
@@ -34,6 +35,12 @@ export interface PoolInfoInitialState {
   status: ActionStatus | undefined;
   errorString?: string;
 }
+
+export interface PoolStatsInitialState {
+  data: LiquidityPoolStats | null;
+  status: ActionStatus | undefined;
+  errorString?: string;
+}
 export interface PoolTransactionsInitialState {
   data: LiquidityPoolTransaction[];
   status: ActionStatus | undefined;
@@ -44,6 +51,15 @@ export interface PoolTransactionsInitialState {
 export interface LiquidityPoolReserve {
   asset: string;
   amount: string;
+  assetCode?: string;
+}
+
+export interface LiquidityPoolAssetInterval {
+  asset: string;
+  "24h": string;
+  "7d": string;
+  "1y": string;
+  assetCode?: string;
 }
 export interface LiquidityPoolOperation {
   [key: string]: any;
@@ -80,4 +96,15 @@ export interface LiquidityPoolInfo {
   totalShares: string;
   totalTrustlines: string;
   fee: number;
+}
+
+export interface LiquidityPoolStats {
+  id: string;
+  assets: LiquidityPoolReserve[];
+  earnedFees: LiquidityPoolAssetInterval[];
+  fee: number | string;
+  shares: string;
+  totalValueLocked: string;
+  tradesCount: number | string;
+  volume: LiquidityPoolAssetInterval[];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1641,14 +1641,15 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@stellar/design-system@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@stellar/design-system/-/design-system-0.4.0.tgz#aee4d96dfb29c59a26cf6212b5db9cdc6df5447a"
-  integrity sha512-mNklETdxTP3BwYsjU3jK3eqXSO0IxGyr5+c8rB/jp3p1XSDYhI2Ef4M4IAadqlg1iXpyFzuY+VJsAaQPOz+kxw==
+"@stellar/design-system@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@stellar/design-system/-/design-system-0.4.1.tgz#2d8d5ab16c49d896a83f87328e1e4e29d0c92818"
+  integrity sha512-xhnISuEkXmKJ1z+zKYzMIb4wmB3vHvGqRkW2WCyDBFTPil1HZoTZ0+kupKjM+Jdh+2V5ZsKqs0BhohONp1UM5g==
   dependencies:
-    configurable-date-input-polyfill "^2.8.2"
-    react-copy-to-clipboard "^5.0.3"
+    configurable-date-input-polyfill "^3.1.0"
+    react-copy-to-clipboard "^5.0.4"
     stellar-identicon-js "^1.0.0"
+    tslib "^2.3.1"
 
 "@stellar/eslint-config@^2.1.1":
   version "2.1.1"
@@ -4011,10 +4012,10 @@ concurrently@^6.2.0:
     tree-kill "^1.2.2"
     yargs "^16.2.0"
 
-configurable-date-input-polyfill@^2.8.2:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/configurable-date-input-polyfill/-/configurable-date-input-polyfill-2.8.2.tgz#825f946bba10889893d789e69b16f027711e94ef"
-  integrity sha512-RTap8vjy02Q4bkse6Lm4GrUlB37tt6/mqy2B6JT5ELkXAQF/qJoC+js+3mERGf3qoXe32Si9ZtKfSxa9Sz7a6A==
+configurable-date-input-polyfill@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/configurable-date-input-polyfill/-/configurable-date-input-polyfill-3.1.0.tgz#4f10e67d5e258c6411ed9f14b6926b05145d758a"
+  integrity sha512-nlqYtBTOy3sjAKWcDXQVe9w/5ZtzazZCc+dXBiKjE2fMg8vG0wLjRi2PTp8QG2nsOChA8T32YnjGBhD48OsbxA==
 
 confusing-browser-globals@^1.0.10:
   version "1.0.10"
@@ -10403,7 +10404,7 @@ react-app-polyfill@^2.0.0:
     regenerator-runtime "^0.13.7"
     whatwg-fetch "^3.4.1"
 
-react-copy-to-clipboard@^5.0.3:
+react-copy-to-clipboard@^5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.4.tgz#42ec519b03eb9413b118af92d1780c403a5f19bf"
   integrity sha512-IeVAiNVKjSPeGax/Gmkqfa/+PuMTBhutEvFUaMQLwE2tS0EXrAdgOpWDX26bWTXF3HrioorR7lr08NqeYUWQCQ==
@@ -12359,7 +12360,7 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3, tslib@^2.3.0:
+tslib@^2.0.3, tslib@^2.3.0, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==


### PR DESCRIPTION
- Moved asset icon fetching to a helper `getAssetAvatarProps()`.
- Saving pool asset avatar props in store. This way we're not fetching them multiple times on the details page. It can slow the initial page load a bit, but we can optimize this later.
- Small tweaks to amount formatting.
- We'll need to improve LP stats store data (and potentially other endpoint responses as well) for easier use in the UI. We're getting data from multiple sources and the data structure is not the same, so we'll need to "normalize" it for more consistent use on the client.

Updated UI

![image](https://user-images.githubusercontent.com/7346473/137759630-d6b866d1-5e6e-4b66-a033-cfcb909ca3d0.png)

Volume/Fee change UI (we don't have the data, but the UI is ready)

![image](https://user-images.githubusercontent.com/7346473/137513583-e36d292d-e5bf-42c5-9f5a-7afc7e344185.png)
