### PR TITLE
Adding Apache 2.0 license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Stellar Development Foundation
+   Copyright 2021 Stellar Development Foundation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
### What
Add Apache 2 license.

### Why
The repo is one of our public repos and so this need an open source license. The license was taken from the [stellar/stellar-demo-wallet](https://github.com/stellar/stellar-demo-wallet) which was taken from the stellar/go repository. The year in line 190 is set to 2020 since that was the year of the first commit in this repo.