### PR TITLE
find the index of timestamp that most closely falls into the segment we're looking for

### DIFF
--- a/src/components/DetailsChart/index.tsx
+++ b/src/components/DetailsChart/index.tsx
@@ -20,7 +20,7 @@ const findSegmentBoundaryIndex = (
   For ex, for 30 days ago, find which timestamp is ~ 30 days ago */
 
   const today = new Date();
-  const priorDateTs = new Date().setDate(today.getDate() - daysAgo);
+  const priorDateTs = new Date().setDate(today.getDate() - daysAgo + 1);
 
   const index = data.findIndex((datum) => datum.ts < priorDateTs);
 

--- a/src/components/DetailsChart/index.tsx
+++ b/src/components/DetailsChart/index.tsx
@@ -15,19 +15,21 @@ const findSegmentBoundaryIndex = (
   data: LiquidityPoolHistory[],
   daysAgo: number,
 ) => {
-  /* iterate over chartData and find the timestamp 
+  /* iterate over poolHistory.data and find the first timestamp 
   that corresponds to the relative date we're looking. 
   For ex, for 30 days ago, find which timestamp is ~ 30 days ago */
 
   const today = new Date();
+
+  // We want to find the first date that is newer than daysAgo + 1
   const priorDateTs = new Date().setDate(today.getDate() - daysAgo + 1);
 
   const index = data.findIndex((datum) => datum.ts < priorDateTs);
 
   /* if the most recent entry is the only one that falls within our boundary
   OR if we can't find any entries that fall within our boundary, 
-  just return the last 2 entries so we have something to look at */
-  return index > 0 ? index : 2;
+  just return index 1 so we have at least 2 points to look at */
+  return index > 0 ? index : 1;
 };
 
 export const DetailsChart = ({

--- a/src/components/DetailsChart/index.tsx
+++ b/src/components/DetailsChart/index.tsx
@@ -11,11 +11,32 @@ interface DetailsChartProps {
   poolHistory: { data: LiquidityPoolHistory[] };
 }
 
+const findSegmentBoundaryIndex = (
+  data: LiquidityPoolHistory[],
+  daysAgo: number,
+) => {
+  /* iterate over chartData and find the timestamp 
+  that corresponds to the relative date we're looking. 
+  For ex, for 30 days ago, find which timestamp is ~ 30 days ago */
+
+  const today = new Date();
+  const priorDateTs = new Date().setDate(today.getDate() - daysAgo);
+
+  const index = data.findIndex((datum) => datum.ts < priorDateTs);
+
+  /* if the most recent entry is the only one that falls within our boundary
+  OR if we can't find any entries that fall within our boundary, 
+  just return the last 2 entries so we have something to look at */
+  return index > 0 ? index : 2;
+};
+
 export const DetailsChart = ({
   isDarkMode,
   poolHistory,
 }: DetailsChartProps) => {
   const [chartData, setChartData] = useState([] as ChartData[]);
+  const [thirtyDayIndex, setThirtyDayIndex] = useState(30);
+  const [sevenDayIndex, setSevenDayIndex] = useState(7);
 
   const generateTheme = () => ({
     primaryColor: getCssVar("--pal-brand-primary"),
@@ -27,7 +48,7 @@ export const DetailsChart = ({
 
   useEffect(() => {
     const formattedData = poolHistory.data.map((entry) => {
-      const dateInstance = new Date(entry.ts * 1000);
+      const dateInstance = new Date(entry.ts);
 
       return {
         x: `${dateInstance.getMonth() + 1}/${dateInstance.getDate()}`,
@@ -35,6 +56,10 @@ export const DetailsChart = ({
       };
     });
     setChartData(formattedData);
+    setThirtyDayIndex(
+      findSegmentBoundaryIndex(poolHistory.data.slice(0, 30), 30),
+    );
+    setSevenDayIndex(findSegmentBoundaryIndex(poolHistory.data.slice(0, 7), 7));
   }, [poolHistory]);
 
   useEffect(() => {
@@ -52,8 +77,8 @@ export const DetailsChart = ({
           }}
           theme={theme}
           timeframes={[
-            { label: "1W", segments: 7 },
-            { label: "1M", segments: 30 },
+            { label: "1W", segments: sevenDayIndex },
+            { label: "1M", segments: thirtyDayIndex },
           ]}
         />
       </Card>

--- a/src/helpers/fetchPoolHistory.ts
+++ b/src/helpers/fetchPoolHistory.ts
@@ -32,7 +32,7 @@ export const fetchPoolHistory = async ({ poolId }: FetchPoolHistoryProps) => {
     shares: fromStroopsToLumen(record.shares),
     totalValueLocked: fromStroopsToLumen(record.total_value_locked),
     trades: record.trades,
-    ts: record.ts,
+    ts: record.ts * 1000,
     volume: formatAmounts(record.volume),
     volumeValue: fromStroopsToLumen(record.volume_value),
   }));


### PR DESCRIPTION
In our charts, we have the ability to zoom in on the last month or the last 7 week of activity. For example, if a user select `1W`, we will select all data points beginning with 7 days ago.

We would love to have a pool `stats-history` entry for every 24h, but this API only aggregates data for days with at least one trade or operation. Because of this, getting the last 7 days of data (for example), is not as easy as grabbing the last 7 entries in the array. Depending on pool activity, the oldest of the last 7 entries could be from a month ago.

To work around this, we can iterate over the list of history entries and find the first entry that falls into our range and use that as the starting point.